### PR TITLE
Async Update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "lc"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lc"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
-.PHONY: async #the DEFAULT linecount func. multi-threaded.
-default:
-	cargo r -- -b
+.PHONY: def #the DEFAULT linecount func. multi-threaded.
+def:
+	@cargo r 
 
-.PHONY: verbose #displays filetree. single-threaded.
-verbose:
-	cargo r -- -v -b
+.PHONY: display #displays filetree. single-threaded.
+display:
+	@cargo r -- -d 
 
-.PHONY: verbose-async #displays filetree. multi-threaded (unreliable print order)
-verbose-async:
-	cargo r -- --test-async
+.PHONY: display-async #displays filetree. multi-threaded (unreliable print order)
+display-async:
+	@cargo r -- --test-async
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+.PHONY: async #the DEFAULT linecount func. multi-threaded.
+default:
+	cargo r -- -b
+
+.PHONY: verbose #displays filetree. single-threaded.
+verbose:
+	cargo r -- -v -b
+
+.PHONY: verbose-async #displays filetree. multi-threaded (unreliable print order)
+verbose-async:
+	cargo r -- --test-async
+


### PR DESCRIPTION
### v0.2 changes
- changed version from 1.0 to 0.2 since it was never truly at "1".
- (default func) is now asynchronous, running on multiple threads.
- 'verbose' renamed -> 'display'. fits the purpose better.
- (display func) is not asynchronous. to run with async on, use (display-async func).
- ignore / visibility checks removed.
- Makefile added for ez runs.

